### PR TITLE
Fixed bug where .await(timeout:) would halt the thread forever

### DIFF
--- a/Sources/AsyncAwait/Task+await.swift
+++ b/Sources/AsyncAwait/Task+await.swift
@@ -20,9 +20,11 @@ extension Task {
             maybeResult = result
             semaphore.signal()
         }
-        if let timeout = timeout, semaphore.wait(timeout: .now() + timeout) == .timedOut {
-            handle.cancel()
-            throw TaskError.timedOut
+        if let timeout = timeout {
+            if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+                handle.cancel()
+                throw TaskError.timedOut
+            }
         } else {
             semaphore.wait()
         }

--- a/Tests/AsyncAwait/AsyncAwaitTests.swift
+++ b/Tests/AsyncAwait/AsyncAwaitTests.swift
@@ -88,6 +88,12 @@ final class AsyncAwaitTests: XCTestCase {
         ensure(task.completionCallCount).stays(1)
     }
 
+    func testAwaitShouldFinishBeforeDeadline() {
+        let task = AsyncAwaitSpy { sleep(for: .milliseconds(5)) }
+        try! task.await(timeout: .milliseconds(25))
+        ensure(task.completionCallCount).becomes(1)
+    }
+
     func testAsyncAwaitFreeFunctionsShouldSucceeedWithValue() {
         let awaitValue = try? await { (done: @escaping (Int) -> Void) -> Void in
             DispatchQueue.global(qos: .unspecified).async {

--- a/Tests/URLTaskManager/URLTaskManagerTests.swift
+++ b/Tests/URLTaskManager/URLTaskManagerTests.swift
@@ -14,7 +14,7 @@ private class Reactor: URLTaskReactor {
         done(nil)
     }
 
-    func shouldExecute(after result: URLTask.Result, from task: URLTask, with _: Handle) -> Bool {
+    func shouldExecute(after result: URLTask.Result, from _: URLTask, with _: Handle) -> Bool {
         if case .success = result {
             let run = count == 0
             count -= 1


### PR DESCRIPTION
Since the timeout guard and the .wait was in the same condition
if the timeout would fail(ie the task succeeded) it would return
false, and end up calling semaphore.wait() a second time